### PR TITLE
autojump_speed_multiplier

### DIFF
--- a/lua/mta/core.lua
+++ b/lua/mta/core.lua
@@ -1043,6 +1043,7 @@ if CLIENT then
 
 	local MTA_OPT_OUT = CreateClientConVar("mta_opt_out", "0", true, true, "Disable criminal events in the lobby for yourself")
 	local MTA_SHOW_WANTEDS = CreateClientConVar("mta_show_wanteds", "1", true, false, "Displays other wanted players")
+	local AUTOJUMP_SPEED_MULTIPLIER = CreateClientConVar("autojump_speed_multiplier", "1.5", true, true, "Multiplies speed by this value every time you jump")
 	cvars.AddChangeCallback("mta_opt_out", function(_, _, new)
 		if tobool(new) and LocalPlayer():GetNWInt("MTAFactor", 0) > 0 then -- cba to network a reset fuck this
 			RunConsoleCommand("kill")

--- a/lua/mta/core.lua
+++ b/lua/mta/core.lua
@@ -1043,7 +1043,7 @@ if CLIENT then
 
 	local MTA_OPT_OUT = CreateClientConVar("mta_opt_out", "0", true, true, "Disable criminal events in the lobby for yourself")
 	local MTA_SHOW_WANTEDS = CreateClientConVar("mta_show_wanteds", "1", true, false, "Displays other wanted players")
-	local AUTOJUMP_SPEED_MULTIPLIER = CreateClientConVar("autojump_speed_multiplier", "1.5", true, true, "Multiplies speed by this value every time you jump")
+
 	cvars.AddChangeCallback("mta_opt_out", function(_, _, new)
 		if tobool(new) and LocalPlayer():GetNWInt("MTAFactor", 0) > 0 then -- cba to network a reset fuck this
 			RunConsoleCommand("kill")

--- a/lua/mta_libs/wanted_constraints.lua
+++ b/lua/mta_libs/wanted_constraints.lua
@@ -21,12 +21,6 @@ local ply_ents_to_remove = {
     end,
 }
 
-gameevent.Listen( "player_connect" )
-hook.Add("player_connect", "PlayerEntityLoaded", function( data )
-	local ply = Entity(data.index + 1) -- For some reason, this hook subtracts one from the entity index, with no explanation as to why.
-	ply:SetSuperJumpMultiplier(ply:GetInfoNum("autojump_speed_multiplier", 1.5)) -- Sets the speed multiplier to the desired setting instead of requiring a suicide to actually set.
-end)
-
 local function constrain(ply, constraint_reason)
     players[ply] = constraint_reason or "unknown"
 

--- a/lua/mta_libs/wanted_constraints.lua
+++ b/lua/mta_libs/wanted_constraints.lua
@@ -20,6 +20,13 @@ local ply_ents_to_remove = {
         sf._didsetoff = true
     end,
 }
+
+gameevent.Listen( "player_connect" )
+hook.Add("player_connect", "PlayerEntityLoaded", function( data )
+	local ply = Entity(data.index + 1) -- For some reason, this hook subtracts one from the entity index, with no explanation as to why.
+	ply:SetSuperJumpMultiplier(ply:GetInfoNum("autojump_speed_multiplier", 1.5)) -- Sets the speed multiplier to the desired setting instead of requiring a suicide to actually set.
+end)
+
 local function constrain(ply, constraint_reason)
     players[ply] = constraint_reason or "unknown"
 
@@ -92,7 +99,7 @@ local function release(ply)
     players[ply] = nil
 
     if ply.SetSuperJumpMultiplier then
-        ply:SetSuperJumpMultiplier(1.5)
+        ply:SetSuperJumpMultiplier(ply:GetInfoNum("autojump_speed_multiplier", 1.5))
     end
 
     hook.Run("MTAPlayerConstraintUpdate", ply, false)


### PR DESCRIPTION
Added to MTA so that it can still correctly be limited. Requires suicide if changed mid game. The SuperJumpMultiplier determines what your speed is multiplied by every time you jump, it's set to 1 in MTA, but can now be changed from 0.1 to 5 outside of wanted.

Defaults to 1.5 because that was the setting before this was added